### PR TITLE
V2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 ## v2.1.0 (2023-11-12)
 
 - Changed the first parameter of the `Parser` class. Now, it accepts absolute path to the template file or a string with template content. Before, it was accepting only the path
-- Added backslash before each PHP native function calls
 - Improved code readability to refactoring the `Parser` class
 
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed the first parameter of the `Parser` class. Now, it accepts absolute path to the template file or a string with template content. Before, it was accepting only the path
 - Improved code readability to refactoring the `Parser` class
 - Added support for `floats` to the lexer and core parser
+- Bug fix, when you pass a relative path as a first argument to the `Parser` class. Now, it will throw an exception with a descriptive message
 
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Changed the first parameter of the `Parser` class. Now, it accepts absolute path to the template file or a string with template content. Before, it was accepting only the path
 - Improved code readability to refactoring the `Parser` class
+- Added support for `floats` to the lexer and core parser
 
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ----
 
+## v2.1.0 (2023-11-12)
+
+- Changed the first parameter of the `Parser` class. Now, it accepts absolute path to the template file or a string with template content. Before, it was accepting only the path
+- Added backslash before each PHP native function calls
+- Improved code readability to refactoring the `Parser` class
+
+----
+
 ## v2.0 (2023-11-11)
 
 - Rewritten the whole package to proper Lexical Analyzer, Parser and Evaluator. Now you can do that you couldn't do before. Like using nested loops, if statements, ternary operators and so on.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ $variables = [
     'show_container' => false,
 ];
 
-$parser = new Parser('hello.html', $variables);
+// Absolute file path or file content as a string
+$file_path = __DIR__ . '/hello.html';
+
+$parser = new Parser($file_path, $variables);
 
 // this will parsed content of hello.html file
 echo $parser->parseHtml();
@@ -87,7 +90,7 @@ use Serhii\GoodbyeHtml\Parser;
 add_shortcode('my_shortcode', 'shortcode_callback');
 
 function shortcode_callback() {
-    $parser = new Parser('shortcodes/main.html', [
+    $parser = new Parser(__DIR__ . '/shortcodes/main.html', [
         'title' => 'Title of the document',
         'uses_php_3_years' => true,
         'show_container' => false,
@@ -98,13 +101,14 @@ function shortcode_callback() {
 
 ## Supported types
 
-Types that you can pass to the parser to include them in the html/text file. Note that not all PHP types are supported for know. More types will be added in next releases.
+Types that you can pass to the parser to include them in the `html/text` file. Note that not all PHP types are supported for know. More types will be added in next releases.
 
 | PHP Type    | Value example |
 | ----------- | ------------- |
 | bool        | true          |
 | string      | 'Is title'    |
 | int         | 24            |
+| float       | 3.1415        |
 
 ## All the available syntax in html/text file
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,6 @@
         "laravel/pint": "dev-main"
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit --testdox"
+        "test": "./vendor/bin/phpunit tests"
     }
 }

--- a/src/Ast/FloatLiteral.php
+++ b/src/Ast/FloatLiteral.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serhii\GoodbyeHtml\Ast;
+
+use Serhii\GoodbyeHtml\Token\Token;
+
+readonly class FloatLiteral implements Expression
+{
+    public function __construct(public Token $token, public float $value)
+    {
+    }
+
+    public function tokenLiteral(): string
+    {
+        return $this->token->literal;
+    }
+
+    public function string(): string
+    {
+        return (string) $this->value;
+    }
+}

--- a/src/CoreParser/CoreParser.php
+++ b/src/CoreParser/CoreParser.php
@@ -9,6 +9,7 @@ use Serhii\GoodbyeHtml\Ast\BlockStatement;
 use Serhii\GoodbyeHtml\Ast\BooleanExpression;
 use Serhii\GoodbyeHtml\Ast\Expression;
 use Serhii\GoodbyeHtml\Ast\ExpressionStatement;
+use Serhii\GoodbyeHtml\Ast\FloatLiteral;
 use Serhii\GoodbyeHtml\Ast\HtmlStatement;
 use Serhii\GoodbyeHtml\Ast\IfExpression;
 use Serhii\GoodbyeHtml\Ast\IntegerLiteral;
@@ -48,6 +49,7 @@ final class CoreParser
         $this->registerPrefix(TokenType::IF, fn () => $this->parseIfExpression());
         $this->registerPrefix(TokenType::LOOP, fn () => $this->parseLoopExpression());
         $this->registerPrefix(TokenType::INTEGER, fn () => $this->parseIntegerLiteral());
+        $this->registerPrefix(TokenType::FLOAT, fn () => $this->parseFloatLiteral());
         $this->registerPrefix(TokenType::STRING, fn () => $this->parseStringLiteral());
         $this->registerPrefix(TokenType::MINUS, fn () => $this->parsePrefixExpression());
         $this->registerPrefix(TokenType::TRUE, fn () => $this->parseBoolean());
@@ -180,6 +182,14 @@ final class CoreParser
         return new IntegerLiteral(
             $this->curToken,
             (int) $this->curToken->literal,
+        );
+    }
+
+    private function parseFloatLiteral(): Expression
+    {
+        return new FloatLiteral(
+            $this->curToken,
+            (float) $this->curToken->literal,
         );
     }
 

--- a/src/Evaluator/Evaluator.php
+++ b/src/Evaluator/Evaluator.php
@@ -7,6 +7,7 @@ namespace Serhii\GoodbyeHtml\Evaluator;
 use Serhii\GoodbyeHtml\Ast\BlockStatement;
 use Serhii\GoodbyeHtml\Ast\BooleanExpression;
 use Serhii\GoodbyeHtml\Ast\ExpressionStatement;
+use Serhii\GoodbyeHtml\Ast\FloatLiteral;
 use Serhii\GoodbyeHtml\Ast\HtmlStatement;
 use Serhii\GoodbyeHtml\Ast\IfExpression;
 use Serhii\GoodbyeHtml\Ast\IntegerLiteral;
@@ -22,6 +23,7 @@ use Serhii\GoodbyeHtml\Ast\VariableExpression;
 use Serhii\GoodbyeHtml\Obj\BlockObj;
 use Serhii\GoodbyeHtml\Obj\BooleanObj;
 use Serhii\GoodbyeHtml\Obj\ErrorObj;
+use Serhii\GoodbyeHtml\Obj\FloatObj;
 use Serhii\GoodbyeHtml\Obj\HtmlObj;
 use Serhii\GoodbyeHtml\Obj\IntegerObj;
 use Serhii\GoodbyeHtml\Obj\ObjType;
@@ -33,6 +35,8 @@ readonly class Evaluator
     {
         if ($node instanceof IntegerLiteral) {
             return new IntegerObj($node->value);
+        } elseif ($node instanceof FloatLiteral) {
+            return new FloatObj($node->value);
         } elseif ($node instanceof StringLiteral) {
             return new StringObj($node->value);
         } elseif ($node instanceof HtmlStatement) {
@@ -186,10 +190,10 @@ readonly class Evaluator
 
     private function evalMinusPrefixOperatorExpression(Obj $right): Obj
     {
-        if ($right->type() !== ObjType::INTEGER_OBJ) {
-            return EvalError::operatorNotAllowed('-', $right);
-        }
-
-        return new IntegerObj(-$right->value());
+        return match ($right->type()) {
+            ObjType::INTEGER_OBJ => new IntegerObj(-$right->value()),
+            ObjType::FLOAT_OBJ => new FloatObj(-$right->value()),
+            default => EvalError::operatorNotAllowed('-', $right),
+        };
     }
 }

--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -75,15 +75,24 @@ final class Lexer
             $type = TokenType::lookupIdentifier($ident);
             $token = new Token($type, $ident);
         } elseif ($this->isNumber($this->char)) {
-            $number = $this->readNumber();
-            $tokenType = str_contains($number, '.') ? TokenType::FLOAT : TokenType::INTEGER;
-            $token = new Token($tokenType, $number);
+            $num = $this->readNumber();
+            $token = new Token($this->readNumberTokenType($num), $num);
         } else {
             $token = Token::illegal($this->char);
             $this->advanceChar();
         }
 
         return $token;
+    }
+
+    private function readNumberTokenType(string $num): TokenType
+    {
+        // If number contains more then one dot, the token is ILLEGAL
+        if (substr_count($num, '.') > 1) {
+            return TokenType::ILLEGAL;
+        }
+
+        return str_contains($num, '.') ? TokenType::FLOAT : TokenType::INTEGER;
     }
 
     private function readHtmlToken(): Token

--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -74,7 +74,7 @@ final class Lexer
             $ident = $this->readIdentifier();
             $type = TokenType::lookupIdentifier($ident);
             $token = new Token($type, $ident);
-        } elseif ($this->isNumber($this->char)) {
+        } elseif ($this->isInteger($this->char)) {
             $token = new Token(TokenType::INTEGER, $this->readNumber());
         } else {
             $token = Token::illegal($this->char);
@@ -133,7 +133,7 @@ final class Lexer
         return preg_match('/[_a-zA-Z]/', $letter) === 1;
     }
 
-    private function isNumber(int|string $number): bool
+    private function isInteger(int|string $number): bool
     {
         if ($number === 0) {
             return false;
@@ -146,7 +146,7 @@ final class Lexer
     {
         $position = $this->position;
 
-        while ($this->isLetter($this->char) || $this->isNumber($this->char)) {
+        while ($this->isLetter($this->char) || $this->isInteger($this->char)) {
             $this->advanceChar();
         }
 
@@ -157,7 +157,7 @@ final class Lexer
     {
         $position = $this->position;
 
-        while ($this->isNumber($this->char)) {
+        while ($this->isInteger($this->char) || $this->char === '.') {
             $this->advanceChar();
         }
 

--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -74,8 +74,10 @@ final class Lexer
             $ident = $this->readIdentifier();
             $type = TokenType::lookupIdentifier($ident);
             $token = new Token($type, $ident);
-        } elseif ($this->isInteger($this->char)) {
-            $token = new Token(TokenType::INTEGER, $this->readNumber());
+        } elseif ($this->isNumber($this->char)) {
+            $number = $this->readNumber();
+            $tokenType = str_contains($number, '.') ? TokenType::FLOAT : TokenType::INTEGER;
+            $token = new Token($tokenType, $number);
         } else {
             $token = Token::illegal($this->char);
             $this->advanceChar();
@@ -139,7 +141,21 @@ final class Lexer
             return false;
         }
 
+        // The number must not contain a dot
+        if (str_contains((string) $number, '.')) {
+            return false;
+        }
+
         return preg_match('/[0-9]/', $number) === 1;
+    }
+
+    private function isNumber(string $number): bool
+    {
+        if ($number === 0) {
+            return false;
+        }
+
+        return preg_match('/[0-9.]/', $number) === 1;
     }
 
     private function readIdentifier(): string

--- a/src/Obj/FloatObj.php
+++ b/src/Obj/FloatObj.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serhii\GoodbyeHtml\Obj;
+
+readonly class FloatObj extends Obj
+{
+    public function __construct(public float $value)
+    {
+    }
+
+    public function type(): ObjType
+    {
+        return ObjType::FLOAT_OBJ;
+    }
+
+    public function value(): float
+    {
+        return $this->value;
+    }
+}

--- a/src/Obj/Obj.php
+++ b/src/Obj/Obj.php
@@ -10,19 +10,24 @@ abstract readonly class Obj
 {
     abstract public function type(): ObjType;
 
-    abstract public function value(): int|string|bool;
+    abstract public function value(): int|string|bool|float;
 
     public static function fromNative(mixed $value, string $name): self
     {
-        if (is_string($value)) {
-            return new StringObj($value);
-        } elseif (is_int($value)) {
-            return new IntegerObj($value);
-        } elseif (is_bool($value)) {
-            return new BooleanObj($value);
-        } else {
-            $msg = sprintf('Provided variable "%s" has unsupported type "%s"', $name, gettype($value));
-            throw new ParserException($msg);
+        $type = gettype($value);
+
+        switch ($type) {
+            case 'string':
+                return new StringObj($value);
+            case 'integer':
+                return new IntegerObj($value);
+            case 'boolean':
+                return new BooleanObj($value);
+            case 'double': // gettype returns 'double' for float values
+                return new FloatObj($value);
+            default:
+                $msg = sprintf('[PARSER_ERROR] Provided variable "%s" has unsupported type "%s"', $name, $type);
+                throw new ParserException($msg);
         }
     }
 }

--- a/src/Obj/ObjType.php
+++ b/src/Obj/ObjType.php
@@ -7,6 +7,7 @@ namespace Serhii\GoodbyeHtml\Obj;
 enum ObjType: string
 {
     case INTEGER_OBJ = 'INTEGER';
+    case FLOAT_OBJ = 'FLOAT';
     case ERROR_OBJ = 'ERROR';
     case STRING_OBJ = 'STRING';
     case HTML_OBJ = 'HTML';

--- a/src/Token/TokenType.php
+++ b/src/Token/TokenType.php
@@ -11,6 +11,7 @@ enum TokenType: string
     case ILLEGAL = 'ILLEGAL';
     case HTML = 'HTML';
     case INTEGER = 'INTEGER';
+    case FLOAT = 'FLOAT';
     case IDENTIFIER = 'IDENTIFIER';
     case IF = 'IF';
     case ELSE = 'ELSE';

--- a/tests/CoreParserTest.php
+++ b/tests/CoreParserTest.php
@@ -6,6 +6,7 @@ namespace Serhii\Tests;
 
 use Serhii\GoodbyeHtml\Ast\BooleanExpression;
 use Serhii\GoodbyeHtml\Ast\ExpressionStatement;
+use Serhii\GoodbyeHtml\Ast\FloatLiteral;
 use Serhii\GoodbyeHtml\Ast\HtmlStatement;
 use Serhii\GoodbyeHtml\Ast\IfExpression;
 use Serhii\GoodbyeHtml\Ast\IntegerLiteral;
@@ -184,6 +185,23 @@ class CoreParserTest extends TestCase
         $this->testInteger($stmt->expression, 5);
     }
 
+    public function testParsingFloatLiteral(): void
+    {
+        $input = '{{ 1.40123 }}';
+
+        $lexer = new Lexer($input);
+        $parser = new CoreParser($lexer);
+
+        $program = $parser->parseProgram();
+
+        $this->checkForErrors($parser, $program->statements, 1);
+
+        /** @var ExpressionStatement $stmt */
+        $stmt = $program->statements[0];
+
+        $this->testFloat($stmt->expression, 1.40123);
+    }
+
     public function testParsingLoopExpression(): void
     {
         $input = <<<HTML
@@ -308,5 +326,11 @@ class CoreParserTest extends TestCase
     {
         self::assertInstanceOf(IntegerLiteral::class, $int);
         self::assertSame($val, $int->value, "Integer must have value '{$val}', got: '{$int->value}'");
+    }
+
+    private static function testFloat($float, $val): void
+    {
+        self::assertInstanceOf(FloatLiteral::class, $float);
+        self::assertSame($val, $float->value, "Float must have value '{$val}', got: '{$float->value}'");
     }
 }

--- a/tests/EvaluatorTest.php
+++ b/tests/EvaluatorTest.php
@@ -24,7 +24,7 @@ class EvaluatorTest extends TestCase
     /**
      * @dataProvider providerForTestEvalIntegerExpression
      */
-    public function testEvalIntegerExpression(string $input, string $expected): void
+    public function testEvalIntegerExpression(string $input, int $expected): void
     {
         $evaluated = $this->testEval($input);
 
@@ -32,15 +32,38 @@ class EvaluatorTest extends TestCase
             $this->fail($evaluated->message);
         }
 
-        $this->assertSame($expected, $evaluated->value());
+        $this->assertSame($expected, (int) $evaluated->value());
     }
 
     public static function providerForTestEvalIntegerExpression(): array
     {
         return [
-            ['{{ 5 }}', '5'],
-            ['{{ 190 }}', '190'],
-            ['{{ -34 }}', '-34'],
+            ['{{ 5 }}', 5],
+            ['{{ 190 }}', 190],
+            ['{{ -34 }}', -34],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestEvalFloatExpression
+     */
+    public function testEvalFloatExpression(string $input, float $expected): void
+    {
+        $evaluated = $this->testEval($input);
+
+        if ($evaluated instanceof ErrorObj) {
+            $this->fail($evaluated->message);
+        }
+
+        $this->assertSame($expected, (float) $evaluated->value());
+    }
+
+    public static function providerForTestEvalFloatExpression(): array
+    {
+        return [
+            ['{{ 3.425 }}', 3.425],
+            ['{{ 1.9 }}', 1.9],
+            ['{{ -3.34 }}', -3.34],
         ];
     }
 

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -318,4 +318,26 @@ class LexerTest extends TestCase
             new Token(TokenType::EOF, ""),
         ]);
     }
+
+    public function testLexingIllegalTokens(): void
+    {
+        $input = <<<HTML
+        {{ 2.3.4 @ $ % ^ & * ( ) }}
+        HTML;
+
+        $this->tokenizeString($input, [
+            new Token(TokenType::OPENING_BRACES, "{{"),
+            new Token(TokenType::ILLEGAL, "2.3.4"),
+            new Token(TokenType::ILLEGAL, "@"),
+            new Token(TokenType::ILLEGAL, "$"),
+            new Token(TokenType::ILLEGAL, "%"),
+            new Token(TokenType::ILLEGAL, "^"),
+            new Token(TokenType::ILLEGAL, "&"),
+            new Token(TokenType::ILLEGAL, "*"),
+            new Token(TokenType::ILLEGAL, "("),
+            new Token(TokenType::ILLEGAL, ")"),
+            new Token(TokenType::CLOSING_BRACES, "}}"),
+            new Token(TokenType::EOF, ""),
+        ]);
+    }
 }

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -77,6 +77,27 @@ class LexerTest extends TestCase
         ]);
     }
 
+    public function testLexingFloats(): void
+    {
+        $input = <<<HTML
+        <h1>{{ 2.5213 }} and {{ -1.3 }}</h1>
+        HTML;
+
+        $this->tokenizeString($input, [
+            new Token(TokenType::HTML, "<h1>"),
+            new Token(TokenType::OPENING_BRACES, "{{"),
+            new Token(TokenType::FLOAT, "2.5213"),
+            new Token(TokenType::CLOSING_BRACES, "}}"),
+            new Token(TokenType::HTML, " and "),
+            new Token(TokenType::OPENING_BRACES, "{{"),
+            new Token(TokenType::MINUS, "-"),
+            new Token(TokenType::FLOAT, "1.3"),
+            new Token(TokenType::CLOSING_BRACES, "}}"),
+            new Token(TokenType::HTML, "</h1>"),
+            new Token(TokenType::EOF, ""),
+        ]);
+    }
+
     public function testLexingBooleans(): void
     {
         $input = <<<HTML


### PR DESCRIPTION
- Changed the first parameter of the `Parser` class. Now, it accepts absolute path to the template file or a string with template content. Before, it was accepting only the path
- Improved code readability to refactoring the `Parser` class
- Added support for `floats` to the lexer and core parser
- Bug fix, when you pass a relative path as a first argument to the `Parser` class. Now, it will throw an exception with a descriptive message