### PR TITLE
V2.6.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+tests/files/before/* linguist-vendored
+tests/files/expect/* linguist-vendored

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ This package is not for creating a full-featured template engine. It's just a si
 
 ## What Goodbye HTML has?
 - [x] Variables
+    - [x] Assigning variables
+    - [x] Using variables
+    - [x] Printing variables
 - [x] If/Else-If/Else statements
 - [x] Ternary expressions
 - [x] Loops
@@ -157,6 +160,7 @@ Infix operators are used to perform math operations or string concatenation. For
 | Divide        | /                | 6 / 3              | int, float                 |
 | Modulo        | %                | 5 % 2              | int, float                 |
 | Concatenate   | .                | 'Hello' . ' world' | string                     |
+| Assigning     | =                | {{ $a = 5 }}       | all the types              |
 
 ## All the available syntax in html/text file
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ## v2.6.0 (2023-11-20)
 
 - Added `elseif` statements to a BNF grammar
+- Added `.gitattributes` file to ignore HTML files in `tests/files` directory
 
 ----
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,8 +7,9 @@
 - Added `elseif` statements to a BNF grammar
 - Added `.gitattributes` file to ignore HTML files in `tests/files` directory
 - Updated code to level 9 of the PHP Stan static analysis tool
-- Fixed typo in the change log file
-- Added variable declaration statement support. Now you can declare variables like this: `{{ $name = 'Anna' }}`. Variable declaration is a statement, and must be surrounded with curly braces.
+- Fixed a typo in the change log file
+- Added variable declaration statement support. Now you can declare variables like this: `{{ $name = 'Anna' }}`. Variable declaration is a statement, and must be surrounded with curly braces
+- 🐛 Bug fix, `$index` variable was accessible outside of the loop. Now, it will throw an error that variable $index is undefined.
 
 ----
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,12 +7,14 @@
 - Added `elseif` statements to a BNF grammar
 - Added `.gitattributes` file to ignore HTML files in `tests/files` directory
 - Updated code to level 9 of the PHP Stan static analysis tool
+- Fixed typo in the change log file
+- Added variable declaration statement support. Now you can declare variables like this: `{{ $name = 'Anna' }}`. Variable declaration is a statement, and must be surrounded with curly braces.
 
 ----
 
 ## v2.5.0 (2023-11-19)
 
-- Added support for `elseif (<expression>)` and `else if (<expression>)` statements like we have in PHP. You can use them like this: `{{ if true }}<h1>True</h1>{{ elseif false }}<h1>False</h1>{{ else }}<h1>Something else</h1>{{ endif }}`
+- Added support for `elseif (<expression>)` and `else if (<expression>)` statements like we have in PHP. You can use them like this: `{{ if true }}<h1>True</h1>{{ elseif false }}<h1>False</h1>{{ else }}<h1>Something else</h1>{{ end }}`
 - Added **PHP Stan** static analysis tool
 - Added **CS Fixer** code style fixer
 - 🐛 Bug fixes in the `Parser.php` class related to readonly properties being set later in the code

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 ----
 
-## v2.6.0 (2023-11-20)
+## v2.6.0 (2023-11-21)
 
 - Added `elseif` statements to a BNF grammar
 - Added `.gitattributes` file to ignore HTML files in `tests/files` directory

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,12 @@
 
 ----
 
+## v2.6.0 (2023-11-20)
+
+- Added `elseif` statements to a BNF grammar
+
+----
+
 ## v2.5.0 (2023-11-19)
 
 - Added support for `elseif (<expression>)` and `else if (<expression>)` statements like we have in PHP. You can use them like this: `{{ if true }}<h1>True</h1>{{ elseif false }}<h1>False</h1>{{ else }}<h1>Something else</h1>{{ endif }}`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 - Added `elseif` statements to a BNF grammar
 - Added `.gitattributes` file to ignore HTML files in `tests/files` directory
+- Updated code to level 9 of the PHP Stan static analysis tool
 
 ----
 

--- a/docs/goodbye-html.bnf
+++ b/docs/goodbye-html.bnf
@@ -59,6 +59,10 @@
 <loop-statement>
     ::= "{{" "loop" <expression> "," <expression> "}}" <block-statement>* "{{" "end" "}}"
 
+<else-if-statement>
+    ::= "{{" "else" "if" <expression> "}}" <block-statement>*
+
 <if-statement>
     ::= "{{" "if" <expression> "}}" <block-statement>* "{{" "end" "}}"
     | "{{" "if" <expression> "}}" <block-statement>* "{{" "else" "}}" <block-statement>* "{{" "end" "}}"
+    | "{{" "if" <expression> "}}" <block-statement>* <else-if-statement>* "{{" "end" "}}"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 parameters:
-	level: 8
+	level: 9
 	paths:
 		- src

--- a/src/Ast/Literals/StringLiteral.php
+++ b/src/Ast/Literals/StringLiteral.php
@@ -20,6 +20,6 @@ readonly class StringLiteral implements Expression
 
     public function string(): string
     {
-        return '"' . $this->value . '"';
+        return sprintf("'%s'", $this->value);
     }
 }

--- a/src/Ast/Statements/AssignStatement.php
+++ b/src/Ast/Statements/AssignStatement.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serhii\GoodbyeHtml\Ast\Statements;
+
+use Serhii\GoodbyeHtml\Ast\Expressions\Expression;
+use Serhii\GoodbyeHtml\Ast\Expressions\VariableExpression;
+use Serhii\GoodbyeHtml\Token\Token;
+
+readonly class AssignStatement implements Statement
+{
+    public function __construct(
+        public Token $token,
+        public VariableExpression $variable,
+        public Expression $value,
+    ) {
+    }
+
+    public function tokenLiteral(): string
+    {
+        return $this->token->literal;
+    }
+
+    public function string(): string
+    {
+        return sprintf("{{ %s = %s }}", $this->variable->string(), $this->value->string());
+    }
+}

--- a/src/Ast/Statements/IfStatement.php
+++ b/src/Ast/Statements/IfStatement.php
@@ -10,7 +10,7 @@ use Serhii\GoodbyeHtml\Token\Token;
 readonly class IfStatement implements Statement
 {
     /**
-     * @param array<int,IfStatement> $elseIfBlocks
+     * @param list<IfStatement> $elseIfBlocks
      */
     public function __construct(
         public Token $token,

--- a/src/CoreParser/CoreParser.php
+++ b/src/CoreParser/CoreParser.php
@@ -49,12 +49,12 @@ class CoreParser
     private Token $peekToken;
 
     /**
-     * @var array<string,Closure>
+     * @var array<string, Closure(): Expression>
      */
     private array $prefixParseFns = [];
 
     /**
-     * @var array<string,Closure>
+     * @var array<string, Closure(Expression): Expression>
      */
     private array $infixParseFns = [];
 

--- a/src/CoreParser/CoreParser.php
+++ b/src/CoreParser/CoreParser.php
@@ -15,6 +15,7 @@ use Serhii\GoodbyeHtml\Ast\Literals\FloatLiteral;
 use Serhii\GoodbyeHtml\Ast\Literals\IntegerLiteral;
 use Serhii\GoodbyeHtml\Ast\Literals\NullLiteral;
 use Serhii\GoodbyeHtml\Ast\Literals\StringLiteral;
+use Serhii\GoodbyeHtml\Ast\Statements\AssignStatement;
 use Serhii\GoodbyeHtml\Ast\Statements\BlockStatement;
 use Serhii\GoodbyeHtml\Ast\Statements\ExpressionStatement;
 use Serhii\GoodbyeHtml\Ast\Statements\HtmlStatement;
@@ -183,8 +184,30 @@ class CoreParser
         return match ($this->curToken->type) {
             TokenType::IF => $this->parseIfStatement(),
             TokenType::LOOP => $this->parseLoopStatement(),
+            TokenType::VAR => $this->parseAssignStatement(),
             default => $this->parseExpressionStatement(),
         };
+    }
+
+    private function parseAssignStatement(): Statement
+    {
+        if (!$this->peekTokenIs(TokenType::ASSIGN)) {
+            return $this->parseExpressionStatement();
+        }
+
+        $token = $this->curToken;
+
+        $variable = $this->parseVariableExpression();
+
+        $this->expectPeek(TokenType::ASSIGN); // skip variable
+
+        $this->nextToken(); // skip "="
+
+        return new AssignStatement(
+            token: $token,
+            variable: $variable,
+            value: $this->parseExpression(Precedence::LOWEST),
+        );
     }
 
     private function parseHtmlStatement(): HtmlStatement
@@ -238,7 +261,7 @@ class CoreParser
         return $leftExp;
     }
 
-    private function parseVariableExpression(): Expression
+    private function parseVariableExpression(): VariableExpression
     {
         return new VariableExpression(
             $this->curToken,

--- a/src/Evaluator/Evaluator.php
+++ b/src/Evaluator/Evaluator.php
@@ -232,6 +232,8 @@ readonly class Evaluator
             return EvalError::wrongArgumentType('loop', ObjType::INTEGER_OBJ, $to);
         }
 
+        $env = Env::newEnclosedEnv($env);
+
         for ($i = $from->value; $i <= $to->value; $i++) {
             $env->set('index', new IntegerObj($i));
 

--- a/src/Evaluator/Evaluator.php
+++ b/src/Evaluator/Evaluator.php
@@ -14,6 +14,7 @@ use Serhii\GoodbyeHtml\Ast\Literals\IntegerLiteral;
 use Serhii\GoodbyeHtml\Ast\Literals\NullLiteral;
 use Serhii\GoodbyeHtml\Ast\Literals\StringLiteral;
 use Serhii\GoodbyeHtml\Ast\Node;
+use Serhii\GoodbyeHtml\Ast\Statements\AssignStatement;
 use Serhii\GoodbyeHtml\Ast\Statements\BlockStatement;
 use Serhii\GoodbyeHtml\Ast\Statements\ExpressionStatement;
 use Serhii\GoodbyeHtml\Ast\Statements\HtmlStatement;
@@ -47,6 +48,7 @@ readonly class Evaluator
             BlockStatement::class => $this->evalBlockStatement($node, $env),
             LoopStatement::class => $this->evalLoopStatement($node, $env),
             ExpressionStatement::class => $this->eval($node->expression, $env),
+            AssignStatement::class => $this->evalAssignStatement($node, $env),
             PrefixExpression::class => $this->evalPrefixExpression($node, $env),
             InfixExpression::class => $this->evalInfixExpression($node, $env),
             VariableExpression::class => $this->evalVariableExpression($node, $env),
@@ -243,6 +245,19 @@ readonly class Evaluator
         }
 
         return new HtmlObj($html);
+    }
+
+    private function evalAssignStatement(AssignStatement $node, Env $env): Obj
+    {
+        $value = $this->eval($node->value, $env);
+
+        if ($value instanceof ErrorObj) {
+            return $value;
+        }
+
+        $env->set($node->variable->value, $value);
+
+        return new NullObj();
     }
 
     private function evalMinusPrefixOperatorExpression(Obj $right): Obj

--- a/src/Evaluator/Evaluator.php
+++ b/src/Evaluator/Evaluator.php
@@ -156,6 +156,7 @@ readonly class Evaluator
         }
 
         $isTrue = $condition->value();
+        $env = Env::newEnclosedEnv($env);
 
         if ($isTrue) {
             return $this->eval($node->block, $env);

--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -65,6 +65,7 @@ class Lexer
             ':' => $this->createTokenAndAdvanceChar(TokenType::COLON),
             '!' => $this->createTokenAndAdvanceChar(TokenType::BANG),
             '.' => $this->createTokenAndAdvanceChar(TokenType::PERIOD),
+            '=' => $this->createTokenAndAdvanceChar(TokenType::ASSIGN),
             default => false,
         };
 

--- a/src/Obj/Env.php
+++ b/src/Obj/Env.php
@@ -15,6 +15,11 @@ class Env
     ) {
     }
 
+    public static function newEnclosedEnv(Env $outer): self
+    {
+        return new self([], $outer);
+    }
+
     public function get(string $key): Obj|null
     {
         if (array_key_exists($key, $this->store)) {

--- a/src/Obj/Env.php
+++ b/src/Obj/Env.php
@@ -7,7 +7,7 @@ namespace Serhii\GoodbyeHtml\Obj;
 class Env
 {
     /**
-     * @param array<string,Obj> $store
+     * @param array<string, Obj> $store
      */
     public function __construct(
         private array $store = [],
@@ -36,7 +36,7 @@ class Env
     }
 
     /**
-     * @param array<string,mixed> $arr
+     * @param array<string, Obj> $arr
      */
     public static function fromArray(array $arr): self
     {

--- a/src/Obj/Env.php
+++ b/src/Obj/Env.php
@@ -15,7 +15,6 @@ class Env
     ) {
     }
 
-    // todo: it's going to be used in the next version when I implement scopes
     public static function newEnclosedEnv(Env $outer): self
     {
         return new self([], $outer);

--- a/src/Obj/Env.php
+++ b/src/Obj/Env.php
@@ -15,11 +15,6 @@ class Env
     ) {
     }
 
-    public static function newEnclosedEnv(Env $outer): self
-    {
-        return new self([], $outer);
-    }
-
     public function get(string $key): Obj|null
     {
         if (array_key_exists($key, $this->store)) {

--- a/src/Obj/Obj.php
+++ b/src/Obj/Obj.php
@@ -17,9 +17,7 @@ abstract readonly class Obj
      */
     public static function fromNative(mixed $value, string $name): self
     {
-        $type = gettype($value);
-
-        switch ($type) {
+        switch (gettype($value)) {
             case 'string':
                 return new StringObj($value);
             case 'integer':
@@ -31,6 +29,7 @@ abstract readonly class Obj
             case 'NULL':
                 return new NullObj();
             default:
+                $type = gettype($value);
                 $msg = sprintf('[PARSER_ERROR] Provided variable "%s" has unsupported type "%s"', $name, $type);
                 throw new ParserException($msg);
         }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -25,7 +25,7 @@ class Parser
 
     /**
      * @param string $file_path Absolute file path or the file content itself
-     * @param array<string,mixed>|null $variables Associative array ['var_name' => 'will be inserted']
+     * @param array<string, mixed>|null $variables Associative array ['var_name' => 'will be inserted']
      */
     public function __construct(
         private readonly string $file_path,

--- a/src/Token/TokenType.php
+++ b/src/Token/TokenType.php
@@ -28,6 +28,7 @@ enum TokenType: string
     case MODULO = '%';
     case PERIOD = '.';
     case BANG = "!";
+    case ASSIGN = '=';
 
     // Delimiters
     case LBRACES = '{{';

--- a/tests/CoreParserTest.php
+++ b/tests/CoreParserTest.php
@@ -248,7 +248,7 @@ class CoreParserTest extends TestCase
 
         $this->assertCount(3, $loop->body->statements, 'Loop body must contain 3 statements');
 
-        /** @var array<int,HtmlStatement|ExpressionStatement> $stmts */
+        /** @var list<HtmlStatement|ExpressionStatement> $stmts */
         $stmts = $loop->body->statements;
 
         $this->testVariable($stmts[1]->expression, 'index');

--- a/tests/CoreParserTest.php
+++ b/tests/CoreParserTest.php
@@ -14,6 +14,7 @@ use Serhii\GoodbyeHtml\Ast\Literals\FloatLiteral;
 use Serhii\GoodbyeHtml\Ast\Literals\IntegerLiteral;
 use Serhii\GoodbyeHtml\Ast\Literals\NullLiteral;
 use Serhii\GoodbyeHtml\Ast\Literals\StringLiteral;
+use Serhii\GoodbyeHtml\Ast\Statements\AssignStatement;
 use Serhii\GoodbyeHtml\Ast\Statements\ExpressionStatement;
 use Serhii\GoodbyeHtml\Ast\Statements\HtmlStatement;
 use Serhii\GoodbyeHtml\Ast\Statements\IfStatement;
@@ -80,7 +81,7 @@ class CoreParserTest extends TestCase
         self::assertSame($val, $bool->value, "Boolean must have value '{$val}', got: '{$bool->value}'");
     }
 
-    public function testParsingVariables(): void
+    public function testParsingVariable(): void
     {
         $input = '{{ $userName }}';
 
@@ -264,7 +265,7 @@ class CoreParserTest extends TestCase
         /** @var ExpressionStatement $stmt */
         $stmt = $this->createProgram($input)->statements[0];
 
-        /** @var StringLiteral $var */
+        /** @var StringLiteral $str */
         $str = $stmt->expression;
 
         $this->testString($str, 'hello');
@@ -400,5 +401,17 @@ class CoreParserTest extends TestCase
         $this->expectExceptionMessage(ParserError::elseIfBlockWrongPlace());
 
         $this->createProgram("{{ if true }}1{{ else }}2{{ elseif true }}3{{ end }}");
+    }
+
+    public function testParsingAssignStatement(): void
+    {
+        $input = "{{ \$herName = 'Anna' }}";
+
+        /** @var AssignStatement $stmt */
+        $stmt = $this->createProgram($input)->statements[0];
+
+        $this->testVariable($stmt->variable, 'herName');
+        $this->testString($stmt->value, 'Anna');
+        $this->assertSame("{{ \$herName = 'Anna' }}", $stmt->string());
     }
 }

--- a/tests/EvaluatorTest.php
+++ b/tests/EvaluatorTest.php
@@ -357,4 +357,25 @@ class EvaluatorTest extends TestCase
             ["{{ 'She\'s ' . 25 }}", "She's 25"],
         ];
     }
+
+    #[DataProvider('providerForTestAssignStatement')]
+    public function testAssignStatement(string $input, string $output): void
+    {
+        $evaluated = $this->testEval($input);
+
+        if ($evaluated instanceof ErrorObj) {
+            $this->fail($evaluated->message);
+        }
+
+        $this->assertSame($output, $evaluated->value());
+    }
+
+    public static function providerForTestAssignStatement(): array
+    {
+        return [
+            ['{{ $herName = "Anna" }}{{ $herName }}', 'Anna'],
+            ['{{ $his_age = 33 }}<h1>{{ $his_age }}</h1>', '<h1>33</h1>'],
+            ['{{ $lang = "PHP" }}{{ $lang="Go" }}{{ $lang }}', 'Go'], // test overriding
+        ];
+    }
 }

--- a/tests/EvaluatorTest.php
+++ b/tests/EvaluatorTest.php
@@ -270,6 +270,19 @@ class EvaluatorTest extends TestCase
         ];
     }
 
+    public function testLoopIndexVariableIsUndefinedOutOfLoop(): void
+    {
+        $input = '{{ loop 1, 2 }}{{ $index }}{{ end }}{{ $index }}';
+
+        $expect = EvalError::variableIsUndefined(
+            new VariableExpression(new Token(TokenType::VAR, 'index'), 'index')
+        )->message;
+
+        $evaluated = $this->testEval($input);
+
+        $this->assertSame($expect, $evaluated->value());
+    }
+
     #[DataProvider('providerForTestErrorHandling')]
     public function testErrorHandling(string $input, string $expectMessage): void
     {

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -398,7 +398,7 @@ class LexerTest extends TestCase
     public function testLexingInfixExpressions(): void
     {
         $input = <<<HTML
-        {{ 4 + 5 - 2 * 3 / 4 % 2 }}
+        {{ 4 + 5 - 2 * 3 / 4 % 2 = 5 }}
         HTML;
 
         $this->tokenizeString($input, [
@@ -414,6 +414,8 @@ class LexerTest extends TestCase
             new Token(TokenType::INT, "4"),
             new Token(TokenType::MODULO, "%"),
             new Token(TokenType::INT, "2"),
+            new Token(TokenType::ASSIGN, "="),
+            new Token(TokenType::INT, "5"),
             new Token(TokenType::RBRACES, "}}"),
             new Token(TokenType::EOF, ""),
         ]);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -30,6 +30,7 @@ class ParserTest extends TestCase
             ['ternary', ['hasContainer' => true]],
             ['readme', ['title' => 'Title of the document', 'uses_php_3_years' => true, 'show_container' => false]],
             ['types', ['weight' => 61.5, 'eyeColor' => null, 'smart' => true, 'tall' => false]],
+            ['scopes', ['amountOfPeople' => 4]],
         ];
     }
 

--- a/tests/files/before/scopes.html
+++ b/tests/files/before/scopes.html
@@ -1,0 +1,17 @@
+<section>
+    {{ $first = true }}
+    {{ $name = "Anna" }}
+    {{ $person = "person" }}
+
+    {{ if $first }}
+        {{ $second = true }}
+
+        {{ if $second }}
+            {{ $areSad = false }}
+
+            <p>Me and {{ $name }} are {{ $areSad ? 'sad' : 'happy' }}!</p>
+        {{ end }}
+    {{ end }}
+
+    <ul>{{ loop 1, $amountOfPeople }}<li>{{ $index }} {{ $person }}</li>{{ end }}</ul>
+</section>

--- a/tests/files/expect/scopes.html
+++ b/tests/files/expect/scopes.html
@@ -1,0 +1,17 @@
+<section>
+    
+    
+    
+
+    
+        
+
+        
+            
+
+            <p>Me and Anna are happy!</p>
+        
+    
+
+    <ul><li>1 person</li><li>2 person</li><li>3 person</li><li>4 person</li></ul>
+</section>


### PR DESCRIPTION
- Added `elseif` statements to a BNF grammar
- Added `.gitattributes` file to ignore HTML files in `tests/files` directory
- Updated code to level 9 of the PHP Stan static analysis tool
- Fixed a typo in the change log file
- Added variable declaration statement support. Now you can declare variables like this: `{{ $name = 'Anna' }}`. Variable declaration is a statement, and must be surrounded with curly braces
- 🐛 Bug fix, `$index` variable was accessible outside the loop. Now, it will throw an error that variable `$index` is undefined.